### PR TITLE
Fetch pages fix and staker borrower fetch funcs

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@unioncredit/data",
-  "version": "1.0.14",
+  "version": "1.0.18",
   "description": "",
   "main": "./lib/index.js",
   "scripts": {

--- a/src/borrowers.ts
+++ b/src/borrowers.ts
@@ -3,6 +3,10 @@ import { OrderDirection } from "./constants";
 import { fetchPages } from "./fetchPages";
 import { objectToWhere } from "./utils";
 
+interface BorrowerAddress {
+  account: string;
+}
+
 interface Borrower {
   id: string;
   account: string;
@@ -48,6 +52,23 @@ export async function fetchBorrowers(
   `;
 
   return fetchPages<Borrower>(query, "borrowers");
+}
+
+export async function fetchBorrowerAddresses(): Promise<string[]> {
+  const query = (skip: number, first: number) => gql`
+      {
+          borrowers(
+              skip: ${skip},
+              first: ${first}
+          )
+          {
+              account
+          }
+      }
+  `;
+
+  const borrowers = await fetchPages<BorrowerAddress>(query, "borrowers");
+  return borrowers.map(b => b.account);
 }
 
 /**

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -6,6 +6,7 @@ export enum OrderDirection {
 export const GRAPH_URLS: { [key: number]: string } = {
   1: "https://api.thegraph.com/subgraphs/name/geraldhost/union",
   5: "https://api.thegraph.com/subgraphs/name/geraldhost/union-goerli",
+  10: "https://api.thegraph.com/subgraphs/name/geraldhost/union-optimism",
   42: "https://api.thegraph.com/subgraphs/name/geraldhost/union-kovan",
   420: "https://api.thegraph.com/subgraphs/name/geraldhost/union-v2-goerli",
   42161: "https://api.thegraph.com/subgraphs/name/geraldhost/union-arbitrum",

--- a/src/fetchPages.ts
+++ b/src/fetchPages.ts
@@ -18,7 +18,7 @@ export async function fetchPages<T>(
   let result: T[] = [];
 
   while (true) {
-    const resp = await request(graphUrl, query(page, pageSize));
+    const resp = await request(graphUrl, query(page * pageSize, pageSize));
     const data = resp[dataKey];
     result = [...result, ...data];
     page++;

--- a/src/stakers.ts
+++ b/src/stakers.ts
@@ -3,6 +3,10 @@ import { OrderDirection } from "./constants";
 import { fetchPages } from "./fetchPages";
 import { objectToWhere } from "./utils";
 
+interface StakerAddress {
+  account: string;
+}
+
 interface Staker {
   id: string;
   account: string;
@@ -52,6 +56,27 @@ export async function fetchStakers(
   `;
 
   return fetchPages<Staker>(query, "stakers");
+}
+
+/**
+ * Get all staker addresses
+ * @returns {Promise} Promise of string[]`
+ */
+export async function fetchStakerAddresses(): Promise<string[]> {
+  const query = (skip: number, first: number) => gql`
+      {
+          stakers(
+              skip: ${skip},
+              first: ${first}
+          )
+          {
+              account
+          }
+      }
+  `;
+
+  const stakers = await fetchPages<StakerAddress>(query, "stakers");
+  return stakers.map(s => s.account);
 }
 
 /**


### PR DESCRIPTION
- Fetch pages was skipping individual entities rather than entire pages
- Added `fetchBorrowerAddresses` and `fetchStakerAddresses` functions